### PR TITLE
Added create function to activity-logger

### DIFF
--- a/src/ActivityLogger.php
+++ b/src/ActivityLogger.php
@@ -51,6 +51,14 @@ class ActivityLogger implements ActivityLoggerInterface
     /**
      * {@inheritdoc}
      */
+    public function create($type, $uuid = null)
+    {
+        return $this->storage->create($type, $uuid);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function find($uuid)
     {
         return $this->storage->find($uuid);

--- a/src/ActivityLoggerInterface.php
+++ b/src/ActivityLoggerInterface.php
@@ -19,6 +19,16 @@ use Sulu\Component\ActivityLog\Model\ActivityLogInterface;
 interface ActivityLoggerInterface
 {
     /**
+     * Create new activity-log.
+     *
+     * @param string $type
+     * @param string $uuid
+     *
+     * @return ActivityLogInterface
+     */
+    public function create($type, $uuid = null);
+
+    /**
      * Returns activity-log by given uuid.
      *
      * @param string $uuid

--- a/src/Model/ActivityLog.php
+++ b/src/Model/ActivityLog.php
@@ -20,18 +20,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class ActivityLog implements ActivityLogInterface
 {
     /**
-     * Create new instance of activity-log.
-     *
-     * @param string $type
-     *
-     * @return self
-     */
-    public static function create($type)
-    {
-        return new self($type);
-    }
-
-    /**
      * @var string
      */
     protected $uuid;
@@ -71,11 +59,15 @@ class ActivityLog implements ActivityLogInterface
      */
     protected $parent;
 
-    public function __construct($type)
+    /**
+     * @param string $type
+     * @param string $uuid
+     */
+    public function __construct($type, $uuid = null)
     {
         $this->type = $type;
 
-        $this->uuid = Uuid::uuid4()->toString();
+        $this->uuid = $uuid ?: Uuid::uuid4()->toString();
     }
 
     /**
@@ -131,11 +123,7 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set title.
-     *
-     * @param string $title
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setTitle($title)
     {
@@ -153,11 +141,7 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set message.
-     *
-     * @param string $message
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setMessage($message)
     {
@@ -175,11 +159,7 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set data.
-     *
-     * @param array $data
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setData($data)
     {
@@ -197,11 +177,7 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set created.
-     *
-     * @param \DateTime $created
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setCreated(\DateTime $created)
     {
@@ -219,11 +195,7 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set creator.
-     *
-     * @param UserInterface $creator
-     *
-     * @return $this
+     * {@inheritdoc}
      */
     public function setCreator(UserInterface $creator = null)
     {
@@ -241,13 +213,9 @@ class ActivityLog implements ActivityLogInterface
     }
 
     /**
-     * Set parent.
-     *
-     * @param ActivityLogInterface $parent
-     *
-     * @return $this
+     * {@inheritdoc}
      */
-    public function setParent(ActivityLogInterface $parent)
+    public function setParent(ActivityLogInterface $parent = null)
     {
         $this->parent = $parent;
 

--- a/src/Model/ActivityLogInterface.php
+++ b/src/Model/ActivityLogInterface.php
@@ -40,11 +40,29 @@ interface ActivityLogInterface
     public function getTitle();
 
     /**
+     * Set title.
+     *
+     * @param string $title
+     *
+     * @return $this
+     */
+    public function setTitle($title);
+
+    /**
      * Returns Message.
      *
      * @return string
      */
     public function getMessage();
+
+    /**
+     * Set message.
+     *
+     * @param string $message
+     *
+     * @return $this
+     */
+    public function setMessage($message);
 
     /**
      * Returns Data.
@@ -54,11 +72,29 @@ interface ActivityLogInterface
     public function getData();
 
     /**
+     * Set data.
+     *
+     * @param string|array $data
+     *
+     * @return $this
+     */
+    public function setData($data);
+
+    /**
      * Returns Created.
      *
      * @return \DateTime
      */
     public function getCreated();
+
+    /**
+     * Set created.
+     *
+     * @param \DateTime $created
+     *
+     * @return $this
+     */
+    public function setCreated(\DateTime $created);
 
     /**
      * Returns Creator.
@@ -68,9 +104,27 @@ interface ActivityLogInterface
     public function getCreator();
 
     /**
+     * Set creator.
+     *
+     * @param UserInterface $creator
+     *
+     * @return $this
+     */
+    public function setCreator(UserInterface $creator = null);
+
+    /**
      * Returns Parent.
      *
      * @return ActivityLogInterface
      */
     public function getParent();
+
+    /**
+     * Set parent.
+     *
+     * @param ActivityLogInterface $parent
+     *
+     * @return $this
+     */
+    public function setParent(ActivityLogInterface $parent = null);
 }

--- a/src/Storage/ActivityLogStorageInterface.php
+++ b/src/Storage/ActivityLogStorageInterface.php
@@ -19,6 +19,16 @@ use Sulu\Component\ActivityLog\Model\ActivityLogInterface;
 interface ActivityLogStorageInterface
 {
     /**
+     * Create a new activity-log.
+     *
+     * @param string $type
+     * @param string $uuid
+     *
+     * @return ActivityLogInterface
+     */
+    public function create($type, $uuid = null);
+
+    /**
      * Find activity-log by uuid.
      *
      * @param string $uuid

--- a/src/Storage/ArrayStorage/ArrayActivityLogStorage.php
+++ b/src/Storage/ArrayStorage/ArrayActivityLogStorage.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\ActivityLog\Storage\ArrayStorage;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sulu\Component\ActivityLog\Model\ActivityLog;
 use Sulu\Component\ActivityLog\Model\ActivityLogInterface;
 use Sulu\Component\ActivityLog\Storage\ActivityLogStorageInterface;
 
@@ -49,6 +50,14 @@ class ArrayActivityLogStorage implements ActivityLogStorageInterface
                 return true;
             }
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($type, $uuid = null)
+    {
+        return new ActivityLog($type, $uuid);
     }
 
     /**

--- a/tests/Functional/ActivityLoggerTest.php
+++ b/tests/Functional/ActivityLoggerTest.php
@@ -60,7 +60,7 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testPersist()
     {
-        $activityLog = ActivityLog::create('default');
+        $activityLog = new ActivityLog('default');
         $this->logger->persist($activityLog);
 
         $this->eventDispatcher->dispatch(Events::PERSIST_ACTIVITY_LOG_EVENT, Argument::type(PersistActivityLogEvent::class))
@@ -71,8 +71,8 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testPersistMultipleTimes()
     {
-        $this->logger->persist(ActivityLog::create('default'));
-        $this->logger->persist(ActivityLog::create('default'));
+        $this->logger->persist(new ActivityLog('default'));
+        $this->logger->persist(new ActivityLog('default'));
 
         $this->eventDispatcher->dispatch(Events::PERSIST_ACTIVITY_LOG_EVENT, Argument::type(PersistActivityLogEvent::class))
             ->shouldBeCalledTimes(2);
@@ -82,8 +82,8 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testFlush()
     {
-        $this->logger->persist(ActivityLog::create('default'));
-        $this->logger->persist(ActivityLog::create('default'));
+        $this->logger->persist(new ActivityLog('default'));
+        $this->logger->persist(new ActivityLog('default'));
 
         $this->eventDispatcher->dispatch(Events::PERSIST_ACTIVITY_LOG_EVENT, Argument::type(PersistActivityLogEvent::class))
             ->shouldBeCalledTimes(2);
@@ -95,7 +95,7 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testFind()
     {
-        $activityLog = ActivityLog::create('default');
+        $activityLog = new ActivityLog('default');
         $this->collection->add($activityLog);
 
         $this->assertEquals($activityLog, $this->logger->find($activityLog->getUuid()));
@@ -103,9 +103,9 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testFindAll()
     {
-        $this->collection->add(ActivityLog::create('default'));
-        $this->collection->add(ActivityLog::create('default'));
-        $this->collection->add(ActivityLog::create('default'));
+        $this->collection->add(new ActivityLog('default'));
+        $this->collection->add(new ActivityLog('default'));
+        $this->collection->add(new ActivityLog('default'));
 
         $this->assertCount(3, $this->logger->findAll());
         $this->assertCount(2, $this->logger->findAll(1, 2));
@@ -114,8 +114,8 @@ class ActivityLoggerTest extends \PHPUnit_Framework_TestCase
 
     public function testFindByParent()
     {
-        $parentActivityLog = ActivityLog::create('default');
-        $activityLog = ActivityLog::create('default');
+        $parentActivityLog = new ActivityLog('default');
+        $activityLog = new ActivityLog('default');
         $activityLog->setParent($parentActivityLog);
 
         $this->logger->persist($parentActivityLog);

--- a/tests/Unit/Storage/ArrayStorage/ArrayActivityStorageTest.php
+++ b/tests/Unit/Storage/ArrayStorage/ArrayActivityStorageTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\ActivityLog\Tests\Unit\Storage\ArrayStorage;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Component\ActivityLog\Model\ActivityLog;
+use Sulu\Component\ActivityLog\Model\ActivityLogInterface;
 use Sulu\Component\ActivityLog\Storage\ArrayStorage\ArrayActivityLogStorage;
 
 /**
@@ -20,11 +21,31 @@ use Sulu\Component\ActivityLog\Storage\ArrayStorage\ArrayActivityLogStorage;
  */
 class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 {
+    public function testCreate()
+    {
+        $storage = new ArrayActivityLogStorage();
+
+        $activityLog = $storage->create('default');
+        $this->assertInstanceOf(ActivityLogInterface::class, $activityLog);
+        $this->assertEquals('default', $activityLog->getType());
+        $this->assertNotNull($activityLog->getUuid());
+    }
+
+    public function testCreateWithUuid()
+    {
+        $storage = new ArrayActivityLogStorage();
+
+        $activityLog = $storage->create('default', '123-123-123');
+        $this->assertInstanceOf(ActivityLogInterface::class, $activityLog);
+        $this->assertEquals('default', $activityLog->getType());
+        $this->assertEquals('123-123-123', $activityLog->getUuid());
+    }
+
     public function testFind()
     {
-        $activityLog = ActivityLog::create('default');
+        $activityLog = new ActivityLog('default');
 
-        $collection = new ArrayCollection([ActivityLog::create('default'), $activityLog, ActivityLog::create('default')]);
+        $collection = new ArrayCollection([new ActivityLog('default'), $activityLog, new ActivityLog('default')]);
         $storage = new ArrayActivityLogStorage($collection);
 
         $this->assertEquals($activityLog, $storage->find($activityLog->getUuid()));
@@ -32,7 +53,7 @@ class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testFindNoResult()
     {
-        $collection = new ArrayCollection([ActivityLog::create('default'), ActivityLog::create('default')]);
+        $collection = new ArrayCollection([new ActivityLog('default'), new ActivityLog('default')]);
         $storage = new ArrayActivityLogStorage($collection);
 
         $this->assertNull($storage->find('123-123-123'));
@@ -40,7 +61,7 @@ class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testFindAll()
     {
-        $activityLogs = [ActivityLog::create('default'), ActivityLog::create('default'), ActivityLog::create('default')];
+        $activityLogs = [new ActivityLog('default'), new ActivityLog('default'), new ActivityLog('default')];
         $collection = new ArrayCollection($activityLogs);
         $storage = new ArrayActivityLogStorage($collection);
 
@@ -51,8 +72,8 @@ class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testFindByParent()
     {
-        $activityLog = ActivityLog::create('default');
-        $activityLogs = [ActivityLog::create('default'), ActivityLog::create('default'), ActivityLog::create('default')];
+        $activityLog = new ActivityLog('default');
+        $activityLogs = [new ActivityLog('default'), new ActivityLog('default'), new ActivityLog('default')];
 
         foreach ($activityLogs as $childActivity) {
             $childActivity->setParent($activityLog);
@@ -68,7 +89,7 @@ class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testPersist()
     {
-        $activityLog = ActivityLog::create('default');
+        $activityLog = new ActivityLog('default');
         $storage = new ArrayActivityLogStorage();
 
         $this->assertEquals($activityLog, $storage->persist($activityLog));
@@ -77,8 +98,8 @@ class ArrayActivityStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testPersistWithParent()
     {
-        $parentActivityLog = ActivityLog::create('default');
-        $activityLog = ActivityLog::create('default');
+        $parentActivityLog = new ActivityLog('default');
+        $activityLog = new ActivityLog('default');
         $activityLog->setParent($parentActivityLog);
 
         $storage = new ArrayActivityLogStorage();


### PR DESCRIPTION
This PR implements a factory-function for activity-logs. This enables the implementation of the storage to return other implementations of the `ActivityLogInterface`. E.g. for a elasticsearch implementation.